### PR TITLE
Search for OBJ and NPC, Camera Fix, and Map List Ordering Fix

### DIFF
--- a/src/main/java/org/lostcitymapeditor/Loaders/MapDataLoader.java
+++ b/src/main/java/org/lostcitymapeditor/Loaders/MapDataLoader.java
@@ -61,11 +61,13 @@ public class MapDataLoader {
         }
 
         try (Stream<Path> paths = Files.list(directory.toPath())) {
+            // Make it alphabetical order - Squid
             List<String> fileNames = paths
-                    .filter(path -> !Files.isDirectory(path))
-                    .filter(path -> path.toString().toLowerCase().endsWith(".jm2"))
-                    .map(path -> path.getFileName().toString())
-                    .collect(Collectors.toList());
+                .filter(path -> !Files.isDirectory(path))
+                .filter(path -> path.toString().toLowerCase().endsWith(".jm2"))
+                .map(path -> path.getFileName().toString())
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .collect(Collectors.toList());
             return FXCollections.observableArrayList(fileNames);
         } catch (IOException e) {
             System.err.println("Error reading directory: " + directoryPath + " - " + e.getMessage());

--- a/src/main/java/org/lostcitymapeditor/Renderer/Camera.java
+++ b/src/main/java/org/lostcitymapeditor/Renderer/Camera.java
@@ -16,17 +16,28 @@ public class Camera {
     private float zoom;
     private float movementSpeed;
     private float mouseSensitivity;
+
+    // Fixed per-scroll "zoom step" (world units). No new dependencies.
+    // Tune this number to taste. It is intentionally decoupled from deltaTime.
+    private float scrollZoomStep = 250.0f;
+
     public Camera(Vector3f position) {
         this.position = position;
+
+        // Preserve your existing coordinate convention.
         this.worldUp = new Vector3f(0.0f, -1.0f, 0.0f);
+
         this.yaw = 90.0f;
         this.pitch = 90.0f;
+
         this.movementSpeed = 3000f;
         this.mouseSensitivity = 0.1f;
         this.zoom = 40.0f;
+
         this.front = new Vector3f(0.0f, 0.0f, -1.0f);
         this.up = new Vector3f();
         this.right = new Vector3f();
+
         updateCameraVectors();
     }
 
@@ -43,19 +54,51 @@ public class Camera {
 
     public void processKeyboard(CameraMovement direction, float deltaTime) {
         float velocity = movementSpeed * deltaTime;
+
+        /*
+            Map-editor UX change retained:
+              - FORWARD/BACKWARD/LEFT/RIGHT are projected onto the "horizontal plane"
+                (plane perpendicular to worldUp), so WASD pans instead of unintentionally
+                moving vertically when pitch is steep.
+         */
+
+        // Project front onto plane perpendicular to worldUp.
+        Vector3f forwardFlat = new Vector3f(front);
+        float frontDotUp = forwardFlat.dot(worldUp);
+        forwardFlat.fma(-frontDotUp, worldUp); // forwardFlat -= (frontDotUp * worldUp)
+
+        if (forwardFlat.lengthSquared() > 1e-8f) {
+            forwardFlat.normalize();
+        } else {
+            forwardFlat.set(0.0f, 0.0f, 0.0f);
+        }
+
+        // Project right onto plane perpendicular to worldUp.
+        Vector3f rightFlat = new Vector3f(right);
+        float rightDotUp = rightFlat.dot(worldUp);
+        rightFlat.fma(-rightDotUp, worldUp); // rightFlat -= (rightDotUp * worldUp)
+
+        if (rightFlat.lengthSquared() > 1e-8f) {
+            rightFlat.normalize();
+        } else {
+            rightFlat.set(0.0f, 0.0f, 0.0f);
+        }
+
         if (direction == CameraMovement.FORWARD)
-            position.add(new Vector3f(front).mul(velocity));
+            position.add(new Vector3f(forwardFlat).mul(velocity));
         if (direction == CameraMovement.BACKWARD)
-            position.sub(new Vector3f(front).mul(velocity));
+            position.sub(new Vector3f(forwardFlat).mul(velocity));
         if (direction == CameraMovement.LEFT)
-            position.sub(new Vector3f(right).mul(velocity));
+            position.sub(new Vector3f(rightFlat).mul(velocity));
         if (direction == CameraMovement.RIGHT)
-            position.add(new Vector3f(right).mul(velocity));
+            position.add(new Vector3f(rightFlat).mul(velocity));
+
+        // Keep your existing zoom behavior as-is (frame-rate scaled via deltaTime).
         if (direction == CameraMovement.ZOOM_IN) {
-            position.sub(new Vector3f(0,1,0).mul(velocity));
+            position.sub(new Vector3f(0, 1, 0).mul(velocity));
         }
         if (direction == CameraMovement.ZOOM_OUT) {
-            position.add(new Vector3f(0,1,0).mul(velocity));
+            position.add(new Vector3f(0, 1, 0).mul(velocity));
         }
     }
 
@@ -74,17 +117,36 @@ public class Camera {
             processKeyboard(CameraMovement.ZOOM_OUT, deltaTime);
     }
 
+    /**
+     * Mouse wheel zoom alias:
+     *   yOffset > 0 => ZOOM_IN
+     *   yOffset < 0 => ZOOM_OUT
+     *
+     * This intentionally does NOT require deltaTime to avoid breaking your callback wiring.
+     */
+    public void processMouseScroll(float yOffset) {
+        if (yOffset > 0.0f) {
+            // Zoom in: move opposite the +Y axis used in your Q/E logic.
+            position.sub(new Vector3f(0, 1, 0).mul(scrollZoomStep));
+        } else if (yOffset < 0.0f) {
+            position.add(new Vector3f(0, 1, 0).mul(scrollZoomStep));
+        }
+    }
+
     public void processMouseMovement(float xOffset, float yOffset, boolean constrainPitch) {
         xOffset *= mouseSensitivity;
         yOffset *= mouseSensitivity;
+
         yaw -= xOffset;
         pitch -= yOffset;
+
         if (constrainPitch) {
             if (pitch < -89.0f)
                 pitch = -89.0f;
             if (pitch > 89.0f)
                 pitch = 89.0f;
         }
+
         updateCameraVectors();
     }
 
@@ -93,6 +155,7 @@ public class Camera {
         newFront.x = (float) (Math.cos(Math.toRadians(yaw)) * Math.cos(Math.toRadians(pitch)));
         newFront.y = (float) Math.sin(Math.toRadians(pitch));
         newFront.z = (float) (Math.sin(Math.toRadians(yaw)) * Math.cos(Math.toRadians(pitch)));
+
         front = newFront.normalize();
         right = new Vector3f(front).cross(worldUp).normalize();
         up = new Vector3f(right).cross(front).normalize();


### PR DESCRIPTION
3 Changes were Made:

#1 Added search capabilities to OBJ and NPC, also modified camera behavior slightly so that it behaves a bit more intuitively. I observed that W and S were effectively the same as Q and E, in a way, when looking at the map from a top-down perspective. 

#2 I found that W and S should move the camera forward and backward along the same horizontal plane, regardless of the angle of the camera, relative to how it should feel. Hard to explain, but it feels much better in my opinion.

#3 Map list is now ordered alphabetically no matter what the filesystem order is (in my case, it was not alphabetical)